### PR TITLE
[EUREKA-650]. Implement POC to automate deploying custom authentication provider

### DIFF
--- a/ecs-folio-authenticator/pom.xml
+++ b/ecs-folio-authenticator/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>keycloak-ecs-folio-authenticator</artifactId>
+  <groupId>org.folio.authentication</groupId>
+  <version>1.0.0</version>
+
+  <parent>
+    <artifactId>folio-keycloak-plugins</artifactId>
+    <groupId>org.folio.keycloak</groupId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
+    <java.version>17</java.version>
+    <junit-jupiter.version>5.11.0</junit-jupiter.version>
+    <maven.compiler.release>17</maven.compiler.release>
+
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
+    <resteasy-jackson2-provider.version>6.2.11.Final</resteasy-jackson2-provider.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <artifactId>keycloak-core</artifactId>
+      <groupId>org.keycloak</groupId>
+      <scope>provided</scope>
+      <version>${keycloak.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>keycloak-server-spi</artifactId>
+      <groupId>org.keycloak</groupId>
+      <scope>provided</scope>
+      <version>${keycloak.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>keycloak-server-spi-private</artifactId>
+      <groupId>org.keycloak</groupId>
+      <scope>provided</scope>
+      <version>${keycloak.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>keycloak-services</artifactId>
+      <groupId>org.keycloak</groupId>
+      <scope>provided</scope>
+      <version>${keycloak.version}</version>
+    </dependency>
+    <dependency>
+      <artifactId>keycloak-saml-core-public</artifactId>
+      <groupId>org.keycloak</groupId>
+      <scope>provided</scope>
+      <version>${keycloak.version}</version>
+    </dependency>
+
+    <dependency>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <scope>test</scope>
+      <version>${junit-jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <groupId>org.mockito</groupId>
+      <scope>test</scope>
+      <version>${mockito-junit-jupiter.version}</version>
+    </dependency>
+    <!-- Provides an implementation to mock OIDCIdentityProvider in the tests -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <scope>test</scope>
+      <version>${resteasy-jackson2-provider.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>keycloak-ecs-folio-authenticator</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <appendAssemblyId>false</appendAssemblyId>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <finalName>${jar.finalName}</finalName>
+        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${java.version}</release>
+        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+      </plugin>
+
+      <plugin>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/ecs-folio-authenticator/pom.xml
+++ b/ecs-folio-authenticator/pom.xml
@@ -17,52 +17,52 @@
   <properties>
     <jar.finalName>${project.artifactId}-${project.version}</jar.finalName>
     <java.version>17</java.version>
-    <junit-jupiter.version>5.11.0</junit-jupiter.version>
-    <maven.compiler.release>17</maven.compiler.release>
-
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <junit-jupiter.version>5.11.4</junit-jupiter.version>
     <mockito-junit-jupiter.version>5.15.2</mockito-junit-jupiter.version>
     <resteasy-jackson2-provider.version>6.2.11.Final</resteasy-jackson2-provider.version>
+
+    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>
     <dependency>
       <artifactId>keycloak-core</artifactId>
       <groupId>org.keycloak</groupId>
-      <scope>provided</scope>
       <version>${keycloak.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>keycloak-server-spi</artifactId>
       <groupId>org.keycloak</groupId>
-      <scope>provided</scope>
       <version>${keycloak.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>keycloak-server-spi-private</artifactId>
       <groupId>org.keycloak</groupId>
-      <scope>provided</scope>
       <version>${keycloak.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>keycloak-services</artifactId>
       <groupId>org.keycloak</groupId>
-      <scope>provided</scope>
       <version>${keycloak.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>keycloak-saml-core-public</artifactId>
       <groupId>org.keycloak</groupId>
-      <scope>provided</scope>
       <version>${keycloak.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <artifactId>junit-jupiter-engine</artifactId>
       <groupId>org.junit.jupiter</groupId>
-      <scope>test</scope>
       <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -73,8 +73,8 @@
     <dependency>
       <artifactId>mockito-junit-jupiter</artifactId>
       <groupId>org.mockito</groupId>
-      <scope>test</scope>
       <version>${mockito-junit-jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
     <!-- Provides an implementation to mock OIDCIdentityProvider in the tests -->
     <dependency>

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -55,7 +55,7 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
   public void action(AuthenticationFlowContext context) {
     MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
     if (formData.containsKey("cancel")) {
-      log.infof("getUserFromForm:: Canceling authentication");
+      log.infof("getUserFromForm:: Cancelling authentication");
       context.cancelLogin();
       return;
     }
@@ -98,7 +98,7 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
       context.getEvent().error(Errors.USER_NOT_FOUND);
       Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
       context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
-      log.info("getUserFromForm:: Cannot retrieve user from form username is empty");
+      log.warnf("getUserFromForm:: Cannot retrieve user from form username is empty");
       return null;
     }
 
@@ -121,11 +121,11 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
       if (mde.getDuplicateFieldName() != null && mde.getDuplicateFieldName().equals(UserModel.EMAIL)) {
         challengeResponse = setDuplicateUserChallenge(context, Errors.EMAIL_IN_USE, Messages.EMAIL_EXISTS,
           AuthenticationFlowError.INVALID_USER);
-        log.info("getUserFromForm:: Cannot retrieve user from from, email is duplicated");
+        log.warnf("getUserFromForm:: Cannot retrieve user from from, email is duplicated");
       } else {
         challengeResponse = setDuplicateUserChallenge(context, Errors.USERNAME_IN_USE, Messages.USERNAME_EXISTS,
           AuthenticationFlowError.INVALID_USER);
-        log.info("getUserFromForm:: Cannot retrieve user from form, username is duplicated");
+        log.warnf("getUserFromForm:: Cannot retrieve user from form, username is duplicated");
       }
       context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
       return null;
@@ -152,44 +152,49 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
   }
 
   private boolean authenticateBy(AuthenticationFlowContext context, FederatedIdentityModel federatedIdentityModel) {
-    String providerId = federatedIdentityModel.getIdentityProvider();
-    IdentityProvider<?> idpInstance = getValidatedIdentityProvider(context, providerId);
+    String providerAlias = federatedIdentityModel.getIdentityProvider();
+    IdentityProvider<?> idpInstance = getValidatedIdentityProvider(context, providerAlias);
     if (idpInstance == null) {
+      log.warnf("authenticateBy:: Cannot find an identity provider");
       return false;
     }
     if (idpInstance instanceof OIDCIdentityProvider oidcIdentityProvider) {
+      log.debugf("authenticateBy:: Found an OIDCIdentityProvider identity provider %s", providerAlias);
       return authenticateWithOidcProvider(context, oidcIdentityProvider, federatedIdentityModel);
     }
-    log.infof("authenticateBy:: IdentityProvider %s is not an instance of OIDCIdentityProvider", providerId);
+    log.warnf("authenticateBy:: IdentityProvider %s is not an instance of OIDCIdentityProvider", providerAlias);
     return false;
   }
 
-  private IdentityProvider<?> getValidatedIdentityProvider(AuthenticationFlowContext context, String providerId) {
-    IdentityProviderModel idpModel = context.getSession().identityProviders().getById(providerId);
-    if (!isIdentityProviderValid(idpModel, providerId)) {
+  private IdentityProvider<?> getValidatedIdentityProvider(AuthenticationFlowContext context, String providerAlias) {
+    IdentityProviderModel idpModel = context.getSession().identityProviders().getByAlias(providerAlias);
+    if (!isIdentityProviderValid(idpModel, providerAlias)) {
+      log.warnf("getValidatedIdentityProvider:: IdentityProviderModel %s is not valid",
+        providerAlias);
       return null;
     }
 
     IdentityProviderFactory<IdentityProvider<?>> idpFactory = getIdentityProviderFactory(context, idpModel);
     if (idpFactory == null) {
-      log.infof("getValidatedIdentityProvider:: IdentityProviderFactory for %s not found", idpModel.getProviderId());
+      log.warnf("getValidatedIdentityProvider:: IdentityProviderFactory for %s not found",
+        providerAlias);
       return null;
     }
 
     return idpFactory.create(context.getSession(), idpModel);
   }
 
-  private boolean isIdentityProviderValid(IdentityProviderModel idpModel, String providerId) {
+  private boolean isIdentityProviderValid(IdentityProviderModel idpModel, String providerAlias) {
     if (idpModel == null) {
-      log.infof("isIdentityProviderValid:: Identity Provider %s not found", providerId);
+      log.warnf("isIdentityProviderValid:: Identity Provider %s not found", providerAlias);
       return false;
     }
     if (!idpModel.isEnabled()) {
-      log.infof("isIdentityProviderValid:: Identity Provider %s is disabled", providerId);
+      log.warnf("isIdentityProviderValid:: Identity Provider %s is disabled", providerAlias);
       return false;
     }
     if (idpModel.isLinkOnly()) {
-      log.infof("isIdentityProviderValid:: Identity Provider %s is not allowed to perform a login", providerId);
+      log.warnf("isIdentityProviderValid:: Identity Provider %s is not allowed to perform a login", providerAlias);
       return false;
     }
     return true;
@@ -239,7 +244,7 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
     String responseString = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
     if (statusCode != HttpStatus.SC_OK) {
-      log.infof("sendTokenRequest:: Authentication failed: status code %s", statusCode);
+      log.warnf("sendTokenRequest:: Authentication failed: status code %s", statusCode);
       throw new AuthenticationException("Invalid response from token endpoint: HTTP: " + statusCode);
     }
     return responseString;

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -2,6 +2,7 @@ package org.folio.authentication;
 
 import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -257,7 +258,8 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
     return params;
   }
 
-  private boolean processTokenResponse(AuthenticationFlowContext context, String responseString) throws Exception {
+  private boolean processTokenResponse(AuthenticationFlowContext context, String responseString)
+    throws JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonNode = mapper.readTree(responseString);
     if (jsonNode.has("access_token")) {

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -83,7 +83,7 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
   public boolean validatePassword(AuthenticationFlowContext context, UserModel user,
                                   MultivaluedMap<String, String> inputData, boolean clearUser) {
     FederatedIdentityModel federatedIdentityModel =
-      (FederatedIdentityModel) context.getSession().removeAttribute("federatedIdentityModel");
+      (FederatedIdentityModel) context.getSession().removeAttribute(FEDERATED_IDENTITY_MODEL);
     if (federatedIdentityModel == null) {
       log.infof("getUserFromForm:: Validating password in non-federated mode");
       return super.validatePassword(context, user, inputData, clearUser);

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -51,6 +51,8 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
 
   private static final Logger log = Logger.getLogger(FolioEcsUsernamePasswordForm.class);
 
+  private static final String FEDERATED_IDENTITY_MODEL = "federatedIdentityModel";
+
   @Override
   public void action(AuthenticationFlowContext context) {
     MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
@@ -70,7 +72,7 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
       FederatedIdentityModel federatedIdentityModel = identityModelOptional.get();
       context.setUser(userModel);
       context.getAuthenticationSession().setAuthNote(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH, "true");
-      context.getSession().setAttribute("federatedIdentityModel", federatedIdentityModel);
+      context.getSession().setAttribute(FEDERATED_IDENTITY_MODEL, federatedIdentityModel);
     } else {
       log.infof("getUserFromForm:: Using non-federated identity authentication");
     }

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -1,0 +1,271 @@
+package org.folio.authentication;
+
+import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.auth.AuthenticationException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.jboss.logging.Logger;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
+import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.provider.IdentityProvider;
+import org.keycloak.broker.provider.IdentityProviderFactory;
+import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.messages.Messages;
+
+public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
+
+  private static final Logger log = Logger.getLogger(FolioEcsUsernamePasswordForm.class);
+
+  @Override
+  public void action(AuthenticationFlowContext context) {
+    MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+    if (formData.containsKey("cancel")) {
+      log.infof("getUserFromForm:: Canceling authentication");
+      context.cancelLogin();
+      return;
+    }
+
+    UserModel userModel = getUserFromForm(context, formData);
+
+    Optional<FederatedIdentityModel> identityModelOptional =
+      context.getSession().users().getFederatedIdentitiesStream(context.getRealm(), userModel).findFirst();
+
+    if (identityModelOptional.isPresent()) {
+      log.infof("getUserFromForm:: Using federated identity authentication");
+      FederatedIdentityModel federatedIdentityModel = identityModelOptional.get();
+      context.setUser(userModel);
+      context.getAuthenticationSession().setAuthNote(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH, "true");
+      context.getSession().setAttribute("federatedIdentityModel", federatedIdentityModel);
+    } else {
+      log.infof("getUserFromForm:: Using non-federated identity authentication");
+    }
+    super.action(context);
+  }
+
+  @Override
+  public boolean validatePassword(AuthenticationFlowContext context, UserModel user,
+                                  MultivaluedMap<String, String> inputData, boolean clearUser) {
+    FederatedIdentityModel federatedIdentityModel =
+      (FederatedIdentityModel) context.getSession().removeAttribute("federatedIdentityModel");
+    if (federatedIdentityModel == null) {
+      log.infof("getUserFromForm:: Validating password in non-federated mode");
+      return super.validatePassword(context, user, inputData, clearUser);
+    }
+
+    log.infof("getUserFromForm:: Validating password in federated mode");
+    boolean check = authenticateBy(context, federatedIdentityModel);
+    return check || badPasswordHandler(context, user);
+  }
+
+  private UserModel getUserFromForm(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
+    String username = Optional.ofNullable(inputData.getFirst(AuthenticationManager.FORM_USERNAME)).orElse("").trim();
+    if (username.isEmpty()) {
+      context.getEvent().error(Errors.USER_NOT_FOUND);
+      Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);
+      context.failureChallenge(AuthenticationFlowError.INVALID_USER, challengeResponse);
+      log.info("getUserFromForm:: Cannot retrieve user from form username is empty");
+      return null;
+    }
+
+    context.getEvent().detail(Details.USERNAME, username);
+    context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
+
+    UserModel user;
+    try {
+      KeycloakSession keycloakSession = context.getSession();
+      RealmModel realm = context.getRealm();
+
+      user = keycloakSession.identityProviders().getAllStream()
+        .map(idp -> getUserFromFederatedIdentity(idp, keycloakSession, realm, username))
+        .filter(Objects::nonNull).findFirst()
+        .orElseGet(() -> KeycloakModelUtils.findUserByNameOrEmail(keycloakSession, realm, username));
+    } catch (ModelDuplicateException mde) {
+      ServicesLogger.LOGGER.modelDuplicateException(mde);
+
+      Response challengeResponse;
+      if (mde.getDuplicateFieldName() != null && mde.getDuplicateFieldName().equals(UserModel.EMAIL)) {
+        challengeResponse = setDuplicateUserChallenge(context, Errors.EMAIL_IN_USE, Messages.EMAIL_EXISTS,
+          AuthenticationFlowError.INVALID_USER);
+        log.info("getUserFromForm:: Cannot retrieve user from from, email is duplicated");
+      } else {
+        challengeResponse = setDuplicateUserChallenge(context, Errors.USERNAME_IN_USE, Messages.USERNAME_EXISTS,
+          AuthenticationFlowError.INVALID_USER);
+        log.info("getUserFromForm:: Cannot retrieve user from form, username is duplicated");
+      }
+      context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+      return null;
+    }
+    testInvalidUser(context, user);
+    return user;
+  }
+
+  private UserModel getUserFromFederatedIdentity(IdentityProviderModel idp, KeycloakSession keycloakSession,
+                                                 RealmModel realm, String username) {
+    return keycloakSession.users()
+        .getUserByFederatedIdentity(realm, new FederatedIdentityModel(idp.getAlias(), username, null));
+  }
+
+  private boolean badPasswordHandler(AuthenticationFlowContext context, UserModel user) {
+    context.getEvent().user(user);
+    context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
+    context.getAuthenticationSession().removeAuthNote(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH);
+
+    Response challengeResponse = challenge(context, Messages.INVALID_USER, FIELD_USERNAME);
+    context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+    context.clearUser();
+    return false;
+  }
+
+  private boolean authenticateBy(AuthenticationFlowContext context, FederatedIdentityModel federatedIdentityModel) {
+    String providerId = federatedIdentityModel.getIdentityProvider();
+    IdentityProvider<?> idpInstance = getValidatedIdentityProvider(context, providerId);
+    if (idpInstance == null) {
+      return false;
+    }
+    if (idpInstance instanceof OIDCIdentityProvider oidcIdentityProvider) {
+      return authenticateWithOidcProvider(context, oidcIdentityProvider, federatedIdentityModel);
+    }
+    log.infof("authenticateBy:: IdentityProvider %s is not an instance of OIDCIdentityProvider", providerId);
+    return false;
+  }
+
+  private IdentityProvider<?> getValidatedIdentityProvider(AuthenticationFlowContext context, String providerId) {
+    IdentityProviderModel idpModel = context.getSession().identityProviders().getById(providerId);
+    if (!isIdentityProviderValid(idpModel, providerId)) {
+      return null;
+    }
+
+    IdentityProviderFactory<IdentityProvider<?>> idpFactory = getIdentityProviderFactory(context, idpModel);
+    if (idpFactory == null) {
+      log.infof("getValidatedIdentityProvider:: IdentityProviderFactory for %s not found", idpModel.getProviderId());
+      return null;
+    }
+
+    return idpFactory.create(context.getSession(), idpModel);
+  }
+
+  private boolean isIdentityProviderValid(IdentityProviderModel idpModel, String providerId) {
+    if (idpModel == null) {
+      log.infof("isIdentityProviderValid:: Identity Provider %s not found", providerId);
+      return false;
+    }
+    if (!idpModel.isEnabled()) {
+      log.infof("isIdentityProviderValid:: Identity Provider %s is disabled", providerId);
+      return false;
+    }
+    if (idpModel.isLinkOnly()) {
+      log.infof("isIdentityProviderValid:: Identity Provider %s is not allowed to perform a login", providerId);
+      return false;
+    }
+    return true;
+  }
+
+  @SuppressWarnings("unchecked")
+  private IdentityProviderFactory<IdentityProvider<?>> getIdentityProviderFactory(AuthenticationFlowContext context,
+                                                                                  IdentityProviderModel idpModel) {
+    Object idpFactory = context.getSession()
+      .getKeycloakSessionFactory()
+      .getProviderFactory(IdentityProvider.class, idpModel.getProviderId());
+    return (IdentityProviderFactory<IdentityProvider<?>>) idpFactory;
+  }
+
+  private boolean authenticateWithOidcProvider(AuthenticationFlowContext context, OIDCIdentityProvider oidcIdp,
+                                               FederatedIdentityModel federatedIdentityModel) {
+    OIDCIdentityProviderConfig config = oidcIdp.getConfig();
+
+    String tokenUrl = config.getTokenUrl();
+    String clientId = config.getClientId();
+    String clientSecret = config.getClientSecret();
+
+    String username = federatedIdentityModel.getUserName();
+    String password = context.getHttpRequest()
+      .getDecodedFormParameters()
+      .getFirst(CredentialRepresentation.PASSWORD);
+    try {
+      String responseString = sendTokenRequest(tokenUrl, clientId, clientSecret, username, password, context);
+      return processTokenResponse(context, responseString);
+    } catch (Exception e) {
+      log.error("Error during authentication with external IdP", e);
+      return false;
+    }
+  }
+
+  private String sendTokenRequest(String tokenUrl, String clientId, String clientSecret, String username,
+                                  String password, AuthenticationFlowContext context)
+    throws AuthenticationException, IOException {
+    List<NameValuePair> params = buildTokenRequestParams(clientId, clientSecret, username, password);
+    HttpPost post = new HttpPost(tokenUrl);
+    post.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+
+    HttpClient httpClient = context.getSession().getProvider(HttpClientProvider.class).getHttpClient();
+    HttpResponse response = httpClient.execute(post);
+
+    int statusCode = response.getStatusLine().getStatusCode();
+    String responseString = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+
+    if (statusCode != HttpStatus.SC_OK) {
+      log.infof("sendTokenRequest:: Authentication failed: status code %s", statusCode);
+      throw new AuthenticationException("Invalid response from token endpoint: HTTP: " + statusCode);
+    }
+    return responseString;
+  }
+
+  private List<NameValuePair> buildTokenRequestParams(String clientId, String clientSecret, String username,
+                                                      String password) {
+    List<NameValuePair> params = new ArrayList<>();
+    params.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD));
+    params.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, clientId));
+    if (clientSecret != null && !clientSecret.isEmpty()) {
+      params.add(new BasicNameValuePair(OAuth2Constants.CLIENT_SECRET, clientSecret));
+    }
+    params.add(new BasicNameValuePair("username", username));
+    params.add(new BasicNameValuePair("password", password));
+    return params;
+  }
+
+  private boolean processTokenResponse(AuthenticationFlowContext context, String responseString) throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode jsonNode = mapper.readTree(responseString);
+    if (jsonNode.has("access_token")) {
+      context.getAuthenticationSession().setAuthNote(AuthenticationManager.PASSWORD_VALIDATED, "true");
+      return true;
+    } else {
+      log.warnf("processTokenResponse:: Authentication failed: no access_token in response");
+      return false;
+    }
+  }
+}

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactory.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactory.java
@@ -1,0 +1,78 @@
+package org.folio.authentication;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.authenticators.browser.UsernamePasswordForm;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class FolioEcsUsernamePasswordFormFactory implements AuthenticatorFactory {
+
+  public static final String PROVIDER_ID = "ecs-folio-auth-usrnm-pwd-form";
+  public static final UsernamePasswordForm SINGLETON = new FolioEcsUsernamePasswordForm();
+  public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+    AuthenticationExecutionModel.Requirement.REQUIRED
+  };
+
+  @Override
+  public Authenticator create(KeycloakSession session) {
+    return SINGLETON;
+  }
+
+  @Override
+  public void init(Config.Scope config) {
+  }
+
+  @Override
+  public void postInit(KeycloakSessionFactory factory) {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public String getId() {
+    return PROVIDER_ID;
+  }
+
+  @Override
+  public String getDisplayType() {
+    return "ECS Folio Username Password Form";
+  }
+
+  @Override
+  public String getReferenceCategory() {
+    return PasswordCredentialModel.TYPE;
+  }
+
+  @Override
+  public boolean isConfigurable() {
+    return false;
+  }
+
+  @Override
+  public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+    return REQUIREMENT_CHOICES;
+  }
+
+  @Override
+  public boolean isUserSetupAllowed() {
+    return false;
+  }
+
+  @Override
+  public String getHelpText() {
+    return "Validates a Folio username and password from login form in ECS setup.";
+  }
+
+  @Override
+  public List<ProviderConfigProperty> getConfigProperties() {
+    return null;
+  }
+}

--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactory.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactory.java
@@ -1,5 +1,6 @@
 package org.folio.authentication;
 
+import java.util.Collections;
 import java.util.List;
 import org.keycloak.Config;
 import org.keycloak.authentication.Authenticator;
@@ -15,7 +16,7 @@ public class FolioEcsUsernamePasswordFormFactory implements AuthenticatorFactory
 
   public static final String PROVIDER_ID = "ecs-folio-auth-usrnm-pwd-form";
   public static final UsernamePasswordForm SINGLETON = new FolioEcsUsernamePasswordForm();
-  public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+  protected static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
     AuthenticationExecutionModel.Requirement.REQUIRED
   };
 
@@ -26,14 +27,17 @@ public class FolioEcsUsernamePasswordFormFactory implements AuthenticatorFactory
 
   @Override
   public void init(Config.Scope config) {
+    // Unsupported operation
   }
 
   @Override
   public void postInit(KeycloakSessionFactory factory) {
+    // Unsupported operation
   }
 
   @Override
   public void close() {
+    // Unsupported operation
   }
 
   @Override
@@ -73,6 +77,6 @@ public class FolioEcsUsernamePasswordFormFactory implements AuthenticatorFactory
 
   @Override
   public List<ProviderConfigProperty> getConfigProperties() {
-    return null;
+    return Collections.emptyList();
   }
 }

--- a/ecs-folio-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/ecs-folio-authenticator/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+org.folio.authentication.FolioEcsUsernamePasswordFormFactory

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactoryTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactoryTest.java
@@ -1,0 +1,88 @@
+package org.folio.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class FolioEcsUsernamePasswordFormFactoryTest {
+
+  private FolioEcsUsernamePasswordFormFactory factory;
+
+  @BeforeEach
+  void init() {
+    factory = new FolioEcsUsernamePasswordFormFactory();
+  }
+
+  @Test
+  public void testCreate() {
+    KeycloakSession session = mock(KeycloakSession.class);
+    assertNotNull(factory.create(session));
+  }
+
+  @Test
+  public void testGetId() {
+    assertEquals("ecs-folio-auth-usrnm-pwd-form", factory.getId());
+  }
+
+  @Test
+  public void testGetDisplayType() {
+    assertEquals("ECS Folio Username Password Form", factory.getDisplayType());
+  }
+
+  @Test
+  public void testGetReferenceCategory() {
+    assertEquals("password", factory.getReferenceCategory());
+  }
+
+  @Test
+  public void testIsConfigurable() {
+    assertFalse(factory.isConfigurable());
+  }
+
+  @Test
+  public void testGetRequirementChoices() {
+    Requirement[] requirements = factory.getRequirementChoices();
+    assertArrayEquals(new Requirement[]{Requirement.REQUIRED}, requirements);
+  }
+
+  @Test
+  public void testIsUserSetupAllowed() {
+    assertFalse(factory.isUserSetupAllowed());
+  }
+
+  @Test
+  public void testGetHelpText() {
+    assertEquals("Validates a Folio username and password from login form in ECS setup.", factory.getHelpText());
+  }
+
+  @Test
+  public void testGetConfigProperties() {
+    assertNull(factory.getConfigProperties());
+  }
+
+  @Test
+  public void testInit() {
+    assertDoesNotThrow(() -> factory.init(null));
+  }
+
+  @Test
+  public void testPostInit() {
+    KeycloakSessionFactory sessionFactory = mock(KeycloakSessionFactory.class);
+    assertDoesNotThrow(() -> factory.postInit(sessionFactory));
+  }
+
+  @Test
+  public void testClose() {
+    assertDoesNotThrow(factory::close);
+  }
+}

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactoryTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormFactoryTest.java
@@ -5,16 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
+import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
-public class FolioEcsUsernamePasswordFormFactoryTest {
+class FolioEcsUsernamePasswordFormFactoryTest {
 
   private FolioEcsUsernamePasswordFormFactory factory;
 
@@ -24,65 +24,65 @@ public class FolioEcsUsernamePasswordFormFactoryTest {
   }
 
   @Test
-  public void testCreate() {
+  void testCreate() {
     KeycloakSession session = mock(KeycloakSession.class);
     assertNotNull(factory.create(session));
   }
 
   @Test
-  public void testGetId() {
+  void testGetId() {
     assertEquals("ecs-folio-auth-usrnm-pwd-form", factory.getId());
   }
 
   @Test
-  public void testGetDisplayType() {
+  void testGetDisplayType() {
     assertEquals("ECS Folio Username Password Form", factory.getDisplayType());
   }
 
   @Test
-  public void testGetReferenceCategory() {
+  void testGetReferenceCategory() {
     assertEquals("password", factory.getReferenceCategory());
   }
 
   @Test
-  public void testIsConfigurable() {
+  void testIsConfigurable() {
     assertFalse(factory.isConfigurable());
   }
 
   @Test
-  public void testGetRequirementChoices() {
+  void testGetRequirementChoices() {
     Requirement[] requirements = factory.getRequirementChoices();
     assertArrayEquals(new Requirement[]{Requirement.REQUIRED}, requirements);
   }
 
   @Test
-  public void testIsUserSetupAllowed() {
+  void testIsUserSetupAllowed() {
     assertFalse(factory.isUserSetupAllowed());
   }
 
   @Test
-  public void testGetHelpText() {
+  void testGetHelpText() {
     assertEquals("Validates a Folio username and password from login form in ECS setup.", factory.getHelpText());
   }
 
   @Test
-  public void testGetConfigProperties() {
-    assertNull(factory.getConfigProperties());
+  void testGetConfigProperties() {
+    assertEquals(Collections.emptyList(), factory.getConfigProperties());
   }
 
   @Test
-  public void testInit() {
+  void testInit() {
     assertDoesNotThrow(() -> factory.init(null));
   }
 
   @Test
-  public void testPostInit() {
+  void testPostInit() {
     KeycloakSessionFactory sessionFactory = mock(KeycloakSessionFactory.class);
     assertDoesNotThrow(() -> factory.postInit(sessionFactory));
   }
 
   @Test
-  public void testClose() {
+  void testClose() {
     assertDoesNotThrow(factory::close);
   }
 }

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
@@ -58,7 +58,7 @@ import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.storage.adapter.InMemoryUserAdapter;
 
-public class FolioEcsUsernamePasswordFormTest {
+class FolioEcsUsernamePasswordFormTest {
 
   private static final String USER_ID = "userId";
   private static final String USERNAME = "username";

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
@@ -54,9 +54,9 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
-import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.storage.adapter.InMemoryUserAdapter;
+import org.mockito.MockedStatic;
 
 class FolioEcsUsernamePasswordFormTest {
 
@@ -70,6 +70,8 @@ class FolioEcsUsernamePasswordFormTest {
   private static final String URL = "url";
   private static final String CLIENT_ID = "clientId";
   private static final String CLIENT_SECRET = "clientSecret";
+  private static final String FEDERATED_IDENTITY_MODEL = "federatedIdentityModel";
+  private static final String TRUE = "true";
   private static final String RESPONSE_JSON = "{\"access_token\":\"token\"}";
   private static final String USER_SET_BEFORE_USERNAME_PASSWORD_AUTH = "USER_SET_BEFORE_USERNAME_PASSWORD_AUTH";
 
@@ -80,13 +82,12 @@ class FolioEcsUsernamePasswordFormTest {
   private UserProvider userProvider;
   private IdentityProviderStorageProvider identityProviderStorageProvider;
   private PasswordHashProvider passwordHashProvider;
-  private AuthenticationExecutionModel executionModel;
   private LoginFormsProvider loginFormsProvider;
   private AuthenticationSessionModel authSession;
-  private RealmModel realm;
   private FreeMarkerLoginFormsProvider freeMarkerLoginFormsProvider;
   @SuppressWarnings("rawtypes")
   private IdentityProviderFactory identityProviderFactory;
+  private KeycloakSessionFactory keycloakSessionFactory;
 
   @BeforeEach
   @SuppressWarnings("unchecked")
@@ -99,29 +100,40 @@ class FolioEcsUsernamePasswordFormTest {
     userProvider = mock(UserProvider.class);
     identityProviderStorageProvider = mock(IdentityProviderStorageProvider.class);
     passwordHashProvider = mock(PasswordHashProvider.class);
-    executionModel = mock(AuthenticationExecutionModel.class);
+
     loginFormsProvider = mock(LoginFormsProvider.class);
     authSession = mock(AuthenticationSessionModel.class);
-    realm = mock(RealmModel.class);
     freeMarkerLoginFormsProvider = mock(FreeMarkerLoginFormsProvider.class);
     identityProviderFactory = mock(IdentityProviderFactory.class);
+    keycloakSessionFactory = mock(KeycloakSessionFactory.class);
 
     when(context.getSession()).thenReturn(session);
     when(context.getHttpRequest()).thenReturn(httpRequest);
     when(context.getAuthenticationSession()).thenReturn(authSession);
+    when(context.getEvent()).thenReturn(mock(EventBuilder.class));
+
+    var realm = mock(RealmModel.class);
     when(context.getRealm()).thenReturn(realm);
     when(realm.getName()).thenReturn(REALM);
-    when(context.getEvent()).thenReturn(mock(EventBuilder.class));
-    when(session.users()).thenReturn(userProvider);
 
-    var keycloakSessionFactory = mock(KeycloakSessionFactory.class);
+    var executionModel = mock(AuthenticationExecutionModel.class);
+    when(context.getExecution()).thenReturn(executionModel);
+    when(executionModel.getId()).thenReturn(EXECUTION_ID);
+
+    when(context.form()).thenReturn(loginFormsProvider);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+    when(session.users()).thenReturn(userProvider);
     when(session.getKeycloakSessionFactory()).thenReturn(keycloakSessionFactory);
+    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
     when(keycloakSessionFactory.getProviderFactory(IdentityProvider.class, PROVIDER_ID))
       .thenReturn(identityProviderFactory);
   }
 
+  // Action Tests
+
   @Test
   void testActionWithCancellation() {
+    // Cancel Form Data Field
     var formData = new MultivaluedHashMap<String, String>();
     formData.add("cancel", "");
 
@@ -134,68 +146,38 @@ class FolioEcsUsernamePasswordFormTest {
 
   @Test
   void testActionWithFederatedIdentity() {
-    var userModel = new LightweightUserAdapter(session, realm, USER_ID);
-    userModel.setUsername(USERNAME);
-
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(USERNAME));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(createFederatedIdentityModel()));
-    when(context.getExecution()).thenReturn(executionModel);
-    when(executionModel.getId()).thenReturn(EXECUTION_ID);
-    when(context.form()).thenReturn(loginFormsProvider);
-    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-    when(context.getAuthenticationSession()).thenReturn(authSession);
+    createIdentityProviders();
+    createPasswordHashProvider(USERNAME);
+    // With Federated Identity
+    var userModel = createInMemoryUserAdapterUserModel();
+    createFederatedIdentities(userModel, Stream.of(createFederatedIdentityModelObj()));
 
     usernamePasswordForm.action(context);
 
     verify(context, atMostOnce()).setUser(any(UserModel.class));
-    verify(authSession, atMostOnce()).setAuthNote(eq(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH), eq("true"));
-    verify(session, atMostOnce()).setAttribute(eq("federatedIdentityModel"), any(FederatedIdentityModel.class));
+    verify(authSession, atMostOnce()).setAuthNote(eq(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH), eq(TRUE));
+    verify(session, atMostOnce()).setAttribute(eq(FEDERATED_IDENTITY_MODEL), any(FederatedIdentityModel.class));
   }
 
   @Test
   void testActionWithoutFederatedIdentity() {
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(USERNAME));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(null);
-    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of());
-    when(context.getExecution()).thenReturn(executionModel);
-    when(executionModel.getId()).thenReturn(EXECUTION_ID);
-    when(context.form()).thenReturn(loginFormsProvider);
-    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-    when(context.getAuthenticationSession()).thenReturn(authSession);
+    createIdentityProviders();
+    createPasswordHashProvider(USERNAME);
+    createFederatedIdentities(null, Stream.of());
 
     usernamePasswordForm.action(context);
 
     verify(context, never()).setUser(any(UserModel.class));
-    verify(authSession, never()).setAuthNote(eq(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH), eq("true"));
-    verify(session, never()).setAttribute(eq("federatedIdentityModel"), any(FederatedIdentityModel.class));
+    verify(authSession, never()).setAuthNote(eq(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH), eq(TRUE));
+    verify(session, never()).setAttribute(eq(FEDERATED_IDENTITY_MODEL), any(FederatedIdentityModel.class));
   }
 
   @Test
   void testActionWithFederatedIdentityAndWithNoUsername() {
-    var userModel = new LightweightUserAdapter(session, realm, USER_ID);
-    userModel.setUsername(USERNAME);
-
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(createFederatedIdentityModel()));
-    when(context.getExecution()).thenReturn(executionModel);
-    when(executionModel.getId()).thenReturn(EXECUTION_ID);
-    when(context.form()).thenReturn(loginFormsProvider);
-    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-    when(context.getAuthenticationSession()).thenReturn(authSession);
+    createIdentityProviders();
+    createPasswordHashProvider(null);
+    var userModel = createInMemoryUserAdapterUserModel();
+    createFederatedIdentities(userModel, Stream.of(createFederatedIdentityModelObj()));
 
     usernamePasswordForm.action(context);
 
@@ -208,26 +190,17 @@ class FolioEcsUsernamePasswordFormTest {
   @ParameterizedTest
   @ValueSource(strings = {UserModel.EMAIL, UserModel.USERNAME})
   void testActionWithFederatedIdentityAndWithDuplicatedUsername(String field) {
-    var userModel = new LightweightUserAdapter(session, realm, USER_ID);
-    userModel.setUsername(USERNAME);
+    createIdentityProviders();
+    createPasswordHashProvider(USERNAME);
 
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(USERNAME));
+    // Duplicated Email or Username Field
     when(userProvider.getUserByFederatedIdentity(any(), any())).thenThrow(
       new ModelDuplicateException("Exception", field));
     when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(
-      Stream.of(createFederatedIdentityModel()));
-    when(context.getExecution()).thenReturn(executionModel);
-    when(executionModel.getId()).thenReturn(EXECUTION_ID);
-    when(context.form()).thenReturn(loginFormsProvider);
-    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      Stream.of(createFederatedIdentityModelObj()));
     when(loginFormsProvider.setError(anyString(), eq(new Object[0]))).thenReturn(loginFormsProvider);
     when(freeMarkerLoginFormsProvider.createResponse(any())).thenReturn(mock(Response.class));
     when(loginFormsProvider.createLoginUsernamePassword()).thenReturn(mock(Response.class));
-    when(context.getAuthenticationSession()).thenReturn(authSession);
 
     usernamePasswordForm.action(context);
 
@@ -238,60 +211,27 @@ class FolioEcsUsernamePasswordFormTest {
       any(Response.class));
   }
 
+  // Validate Password Tests
+
   @Test
   void testValidatePasswordWithFederatedIdentity() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
-
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
-
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
-
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    // With Federated Identity
+    bindFederatedIdentity(userModel);
+    createPasswordHashProvider(USERNAME);
 
     try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+      var httpResponse = createHttpResponse(HttpStatus.SC_OK);
+      var httpEntity = createHttpEntity(httpResponse);
+      var httpClient = createHttpClient(httpResponse, mockedStatic, httpEntity, RESPONSE_JSON);
+      createHttpClientProvider(httpClient);
 
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
-        .thenReturn(RESPONSE_JSON);
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
       assertTrue(result);
 
@@ -301,46 +241,19 @@ class FolioEcsUsernamePasswordFormTest {
 
   @Test
   void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProviderFactory() {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
 
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
-
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
-
-    var keycloakSessionFactory = mock(KeycloakSessionFactory.class);
-    when(session.getKeycloakSessionFactory()).thenReturn(keycloakSessionFactory);
+    // No Identity Provider Factory
     when(keycloakSessionFactory.getProviderFactory(IdentityProvider.class, PROVIDER_ID))
       .thenReturn(null);
 
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
-
-    when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-    when(context.getExecution()).thenReturn(executionModel);
-    when(executionModel.getId()).thenReturn(EXECUTION_ID);
-    when(context.form()).thenReturn(loginFormsProvider);
-    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-    when(context.getAuthenticationSession()).thenReturn(authSession);
-
-    var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
     assertFalse(result);
 
@@ -348,353 +261,118 @@ class FolioEcsUsernamePasswordFormTest {
   }
 
   @Test
-  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProviderModel() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProviderModel() {
+    // No Identity Provider Model
+    createIdentityProviderByAlias(null);
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
 
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(null);
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    assertFalse(result);
 
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
-
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
-
-    try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
-        .thenReturn(RESPONSE_JSON);
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(null);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
-
-      assertFalse(result);
-
-      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
-    }
+    verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
   }
 
   @Test
-  void testValidatePasswordWithFederatedIdentityAndWithLinkOnlyIdentityProviderModel() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
-
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
-
-    var identityProviderModel = createIdentityProviderModel();
-    identityProviderModel.setLinkOnly(true);
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(identityProviderModel);
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
-
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
-
-    try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
-        .thenReturn(RESPONSE_JSON);
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
-
-      assertFalse(result);
-
-      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
-    }
-  }
-
-  @Test
-  void testValidatePasswordWithDisabledFederatedIdentity() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
-
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
-
-    var identityProviderModel = createIdentityProviderModel();
+  void testValidatePasswordWithDisabledFederatedIdentity() {
+    // Disabled Identity Provider
+    var identityProviderModel = createIdentityProviderModelObj();
     identityProviderModel.setEnabled(false);
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(identityProviderModel);
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    createIdentityProviderByAlias(identityProviderModel);
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
 
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+    assertFalse(result);
 
-    try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
-        .thenReturn(RESPONSE_JSON);
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
-
-      assertFalse(result);
-
-      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
-    }
+    verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
   }
 
   @Test
-  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProvider() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+  void testValidatePasswordWithFederatedIdentityAndWithLinkOnlyIdentityProviderModel() {
+    // Link Only Identity Provider
+    var identityProviderModel = createIdentityProviderModelObj();
+    identityProviderModel.setLinkOnly(true);
+    createIdentityProviderByAlias(identityProviderModel);
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
 
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    assertFalse(result);
+
+    verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProvider() {
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
+
+    // No Identity Provider
     when(identityProviderFactory.create(any(), any())).thenReturn(null);
 
-    try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+    assertFalse(result);
 
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
-        .thenReturn(RESPONSE_JSON);
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
-
-      assertFalse(result);
-
-      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
-    }
+    verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
   }
 
   @Test
-  void testValidatePasswordWithFederatedIdentityAndWithWrongIdentityProvider() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+  void testValidatePasswordWithFederatedIdentityAndWithWrongIdentityProvider() {
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
 
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+    // Wrong Identity Provider
+    when(identityProviderFactory.create(any(), any())).thenReturn(mock(IdentityProvider.class));
 
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
-    var identityProvider = mock(IdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(identityProvider);
+    assertFalse(result);
 
-    try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
-        .thenReturn(RESPONSE_JSON);
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
-
-      assertFalse(result);
-
-      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
-    }
+    verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
   }
 
   @Test
   void testValidatePasswordWithFederatedIdentityAndWithNoAccessToken() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
-
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
-
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
-
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
+    createPasswordHashProvider(null);
 
     try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+      var httpResponse = createHttpResponse(HttpStatus.SC_OK);
+      var httpEntity = createHttpEntity(httpResponse);
+      // No Access Token
+      var httpClient = createHttpClient(httpResponse, mockedStatic, httpEntity, "");
+      createHttpClientProvider(httpClient);
 
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8))).thenReturn("");
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
       assertFalse(result);
 
@@ -704,57 +382,23 @@ class FolioEcsUsernamePasswordFormTest {
 
   @Test
   void testValidatePasswordWithFederatedIdentityAndWithNoOkStatus() throws IOException {
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
-
-    var federatedIdentityModel = mock(FederatedIdentityModel.class);
-    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
-    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
-
-    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
-    when(session.users()).thenReturn(userProvider);
-    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
-    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
-    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
-
-    var config = mock(OIDCIdentityProviderConfig.class);
-    when(config.getTokenUrl()).thenReturn(URL);
-    when(config.getClientId()).thenReturn(CLIENT_ID);
-    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
-
-    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
-    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
-    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
+    createPasswordHashProvider(null);
 
     try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      var httpResponse = mock(CloseableHttpResponse.class);
-      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
-      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_GATEWAY_TIMEOUT);
+      // No OK Status (Error code 504)
+      var httpResponse = createHttpResponse(HttpStatus.SC_GATEWAY_TIMEOUT);
+      var httpEntity = createHttpEntity(httpResponse);
+      var httpClient = createHttpClient(httpResponse, mockedStatic, httpEntity, "");
+      createHttpClientProvider(httpClient);
 
-      var httpEntity = mock(HttpEntity.class);
-      when(httpResponse.getEntity()).thenReturn(httpEntity);
-      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
-      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
-
-      var httpClient = mock(CloseableHttpClient.class);
-      when(httpClient.execute(any())).thenReturn(httpResponse);
-      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8))).thenReturn("");
-      var httpClientProvider = mock(HttpClientProvider.class);
-      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
-      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
-      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
-      when(context.getExecution()).thenReturn(executionModel);
-      when(executionModel.getId()).thenReturn(EXECUTION_ID);
-      when(context.form()).thenReturn(loginFormsProvider);
-      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
-      when(context.getAuthenticationSession()).thenReturn(authSession);
-
-      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
       assertFalse(result);
 
@@ -764,38 +408,128 @@ class FolioEcsUsernamePasswordFormTest {
 
   @Test
   void testValidatePasswordWithNoFederatedIdentity() {
-    when(session.removeAttribute("federatedIdentityModel")).thenReturn(null);
+    var userModel = createInMemoryUserAdapterUserModel();
 
-    var userModel = mock(InMemoryUserAdapter.class);
-    when(userModel.getId()).thenReturn(USER_ID);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.getUsername()).thenReturn(USERNAME);
-    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
-    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+    // No Federated Identity
+    when(session.removeAttribute(FEDERATED_IDENTITY_MODEL)).thenReturn(null);
 
-    var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
 
     assertTrue(result);
 
     verify(userModel.credentialManager(), atMostOnce()).isValid(any(CredentialInput[].class));
   }
 
-  private MultivaluedHashMap<String, String> createFormData(String username) {
+  // Utility Methods
+
+  private MultivaluedHashMap<String, String> createFormDataObj(String username) {
     var formData = new MultivaluedHashMap<String, String>();
     formData.add("username", username);
     formData.add("password", FolioEcsUsernamePasswordFormTest.PASSWORD);
     return formData;
   }
 
-  private FederatedIdentityModel createFederatedIdentityModel() {
-    return new FederatedIdentityModel(PROVIDER_ALIAS, USERNAME, null);
-  }
-
-  private IdentityProviderModel createIdentityProviderModel() {
+  private IdentityProviderModel createIdentityProviderModelObj() {
     var identityProviderModel = new IdentityProviderModel();
     identityProviderModel.setProviderId(PROVIDER_ID);
     identityProviderModel.setAlias(PROVIDER_ALIAS);
     identityProviderModel.setEnabled(true);
     return identityProviderModel;
+  }
+
+  private void createIdentityProviders() {
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModelObj()));
+  }
+
+  private void createIdentityProviderByAlias(IdentityProviderModel identityProviderModelObj) {
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(identityProviderModelObj);
+  }
+
+  private FederatedIdentityModel createFederatedIdentityModelWithRemoveAttr() {
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute(FEDERATED_IDENTITY_MODEL)).thenReturn(federatedIdentityModel);
+    return federatedIdentityModel;
+  }
+
+  private void createPasswordHashProvider(String username) {
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormDataObj(username));
+  }
+
+  private FederatedIdentityModel createFederatedIdentityModelObj() {
+    return new FederatedIdentityModel(PROVIDER_ALIAS, USERNAME, null);
+  }
+
+  private void bindFederatedIdentity(UserModel userModel) {
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+  }
+
+  private void createFederatedIdentities(UserModel userModel,
+                                         Stream<FederatedIdentityModel> federatedIdentityModelObj) {
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(federatedIdentityModelObj);
+  }
+
+  private void bindIdentityProviderAndFederatedIdentityModel(FederatedIdentityModel federatedIdentityModel) {
+    when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+  }
+
+  private InMemoryUserAdapter createInMemoryUserAdapterUserModel() {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+    return userModel;
+  }
+
+  private OIDCIdentityProviderConfig createOidcIdentityProviderConfig() {
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+    return config;
+  }
+
+  private void createOidcIdentityProvider(OIDCIdentityProviderConfig oidcIdentityProviderConfig) {
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(oidcIdentityProviderConfig);
+  }
+
+  private void createHttpClientProvider(CloseableHttpClient httpClient) {
+    var httpClientProvider = mock(HttpClientProvider.class);
+    when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+    when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+  }
+
+  private HttpEntity createHttpEntity(CloseableHttpResponse httpResponse) throws IOException {
+    var httpEntity = mock(HttpEntity.class);
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+    when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+    return httpEntity;
+  }
+
+  private CloseableHttpClient createHttpClient(CloseableHttpResponse httpResponse,
+                                               MockedStatic<EntityUtils> mockedStatic,
+                                               HttpEntity httpEntity, String responseJson) throws IOException {
+    var httpClient = mock(CloseableHttpClient.class);
+    when(httpClient.execute(any())).thenReturn(httpResponse);
+    mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+      .thenReturn(responseJson);
+    return httpClient;
+  }
+
+  private CloseableHttpResponse createHttpResponse(int scOk) {
+    var httpResponse = mock(CloseableHttpResponse.class);
+    when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+    when(httpResponse.getStatusLine().getStatusCode()).thenReturn(scOk);
+    return httpResponse;
   }
 }

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
@@ -85,9 +85,11 @@ class FolioEcsUsernamePasswordFormTest {
   private AuthenticationSessionModel authSession;
   private RealmModel realm;
   private FreeMarkerLoginFormsProvider freeMarkerLoginFormsProvider;
+  @SuppressWarnings("rawtypes")
   private IdentityProviderFactory identityProviderFactory;
 
   @BeforeEach
+  @SuppressWarnings("unchecked")
   void setUp() {
     usernamePasswordForm = new FolioEcsUsernamePasswordForm();
 
@@ -249,7 +251,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -281,7 +283,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -310,7 +312,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -330,7 +332,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
     when(oidcIdentityProvider.getConfig()).thenReturn(config);
 
-    when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+    when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
     when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
     when(context.getExecution()).thenReturn(executionModel);
     when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -358,7 +360,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(null);
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(null);
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -390,7 +392,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(null);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -421,7 +423,7 @@ class FolioEcsUsernamePasswordFormTest {
     var identityProviderModel = createIdentityProviderModel();
     identityProviderModel.setLinkOnly(true);
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(identityProviderModel);
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(identityProviderModel);
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -453,7 +455,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -484,7 +486,7 @@ class FolioEcsUsernamePasswordFormTest {
     var identityProviderModel = createIdentityProviderModel();
     identityProviderModel.setEnabled(false);
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(identityProviderModel);
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(identityProviderModel);
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -516,7 +518,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -545,7 +547,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -569,7 +571,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -598,7 +600,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -624,7 +626,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -653,7 +655,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -684,7 +686,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);
@@ -713,7 +715,7 @@ class FolioEcsUsernamePasswordFormTest {
     when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
 
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
-    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.identityProviders().getByAlias(PROVIDER_ALIAS)).thenReturn(createIdentityProviderModel());
     when(session.users()).thenReturn(userProvider);
     when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
     when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
@@ -744,7 +746,7 @@ class FolioEcsUsernamePasswordFormTest {
       var httpClientProvider = mock(HttpClientProvider.class);
       when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
       when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
-      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ALIAS);
       when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
       when(context.getExecution()).thenReturn(executionModel);
       when(executionModel.getId()).thenReturn(EXECUTION_ID);

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
@@ -1,0 +1,799 @@
+package org.folio.authentication;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.provider.IdentityProvider;
+import org.keycloak.broker.provider.IdentityProviderFactory;
+import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.credential.CredentialInput;
+import org.keycloak.credential.CredentialModel;
+import org.keycloak.credential.hash.PasswordHashProvider;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.storage.adapter.InMemoryUserAdapter;
+
+public class FolioEcsUsernamePasswordFormTest {
+
+  private static final String USER_ID = "userId";
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+  private static final String PROVIDER_ID = "providerId";
+  private static final String PROVIDER_ALIAS = "providerAlias";
+  private static final String REALM = "realm";
+  private static final String EXECUTION_ID = "executionId";
+  private static final String URL = "url";
+  private static final String CLIENT_ID = "clientId";
+  private static final String CLIENT_SECRET = "clientSecret";
+  private static final String RESPONSE_JSON = "{\"access_token\":\"token\"}";
+  private static final String USER_SET_BEFORE_USERNAME_PASSWORD_AUTH = "USER_SET_BEFORE_USERNAME_PASSWORD_AUTH";
+
+  private FolioEcsUsernamePasswordForm usernamePasswordForm;
+  private KeycloakSession session;
+  private AuthenticationFlowContext context;
+  private HttpRequest httpRequest;
+  private UserProvider userProvider;
+  private IdentityProviderStorageProvider identityProviderStorageProvider;
+  private PasswordHashProvider passwordHashProvider;
+  private AuthenticationExecutionModel executionModel;
+  private LoginFormsProvider loginFormsProvider;
+  private AuthenticationSessionModel authSession;
+  private RealmModel realm;
+  private FreeMarkerLoginFormsProvider freeMarkerLoginFormsProvider;
+  private IdentityProviderFactory identityProviderFactory;
+
+  @BeforeEach
+  void setUp() {
+    usernamePasswordForm = new FolioEcsUsernamePasswordForm();
+
+    session = mock(KeycloakSession.class);
+    context = mock(AuthenticationFlowContext.class);
+    httpRequest = mock(HttpRequest.class);
+    userProvider = mock(UserProvider.class);
+    identityProviderStorageProvider = mock(IdentityProviderStorageProvider.class);
+    passwordHashProvider = mock(PasswordHashProvider.class);
+    executionModel = mock(AuthenticationExecutionModel.class);
+    loginFormsProvider = mock(LoginFormsProvider.class);
+    authSession = mock(AuthenticationSessionModel.class);
+    realm = mock(RealmModel.class);
+    freeMarkerLoginFormsProvider = mock(FreeMarkerLoginFormsProvider.class);
+    identityProviderFactory = mock(IdentityProviderFactory.class);
+
+    when(context.getSession()).thenReturn(session);
+    when(context.getHttpRequest()).thenReturn(httpRequest);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+    when(context.getRealm()).thenReturn(realm);
+    when(realm.getName()).thenReturn(REALM);
+    when(context.getEvent()).thenReturn(mock(EventBuilder.class));
+    when(session.users()).thenReturn(userProvider);
+
+    var keycloakSessionFactory = mock(KeycloakSessionFactory.class);
+    when(session.getKeycloakSessionFactory()).thenReturn(keycloakSessionFactory);
+    when(keycloakSessionFactory.getProviderFactory(IdentityProvider.class, PROVIDER_ID))
+      .thenReturn(identityProviderFactory);
+  }
+
+  @Test
+  void testActionWithCancellation() {
+    var formData = new MultivaluedHashMap<String, String>();
+    formData.add("cancel", "");
+
+    when(httpRequest.getDecodedFormParameters()).thenReturn(formData);
+
+    usernamePasswordForm.action(context);
+
+    verify(context).cancelLogin();
+  }
+
+  @Test
+  void testActionWithFederatedIdentity() {
+    var userModel = new LightweightUserAdapter(session, realm, USER_ID);
+    userModel.setUsername(USERNAME);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(USERNAME));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(createFederatedIdentityModel()));
+    when(context.getExecution()).thenReturn(executionModel);
+    when(executionModel.getId()).thenReturn(EXECUTION_ID);
+    when(context.form()).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+
+    usernamePasswordForm.action(context);
+
+    verify(context, atMostOnce()).setUser(any(UserModel.class));
+    verify(authSession, atMostOnce()).setAuthNote(eq(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH), eq("true"));
+    verify(session, atMostOnce()).setAttribute(eq("federatedIdentityModel"), any(FederatedIdentityModel.class));
+  }
+
+  @Test
+  void testActionWithoutFederatedIdentity() {
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(USERNAME));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(null);
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of());
+    when(context.getExecution()).thenReturn(executionModel);
+    when(executionModel.getId()).thenReturn(EXECUTION_ID);
+    when(context.form()).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+
+    usernamePasswordForm.action(context);
+
+    verify(context, never()).setUser(any(UserModel.class));
+    verify(authSession, never()).setAuthNote(eq(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH), eq("true"));
+    verify(session, never()).setAttribute(eq("federatedIdentityModel"), any(FederatedIdentityModel.class));
+  }
+
+  @Test
+  void testActionWithFederatedIdentityAndWithNoUsername() {
+    var userModel = new LightweightUserAdapter(session, realm, USER_ID);
+    userModel.setUsername(USERNAME);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(createFederatedIdentityModel()));
+    when(context.getExecution()).thenReturn(executionModel);
+    when(executionModel.getId()).thenReturn(EXECUTION_ID);
+    when(context.form()).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+
+    usernamePasswordForm.action(context);
+
+    verify(context, atMostOnce()).setUser(any());
+    verify(authSession, atMostOnce()).setAuthNote(any(), any());
+    verify(session, atMostOnce()).setAttribute(any(), any());
+    verify(context, atMostOnce()).failureChallenge(eq(AuthenticationFlowError.INVALID_USER), any(Response.class));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {UserModel.EMAIL, UserModel.USERNAME})
+  void testActionWithFederatedIdentityAndWithDuplicatedUsername(String field) {
+    var userModel = new LightweightUserAdapter(session, realm, USER_ID);
+    userModel.setUsername(USERNAME);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModel()));
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(USERNAME));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenThrow(
+      new ModelDuplicateException("Exception", field));
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(
+      Stream.of(createFederatedIdentityModel()));
+    when(context.getExecution()).thenReturn(executionModel);
+    when(executionModel.getId()).thenReturn(EXECUTION_ID);
+    when(context.form()).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.setError(anyString(), eq(new Object[0]))).thenReturn(loginFormsProvider);
+    when(freeMarkerLoginFormsProvider.createResponse(any())).thenReturn(mock(Response.class));
+    when(loginFormsProvider.createLoginUsernamePassword()).thenReturn(mock(Response.class));
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+
+    usernamePasswordForm.action(context);
+
+    verify(context, atMostOnce()).setUser(any());
+    verify(authSession, times(3)).setAuthNote(any(), any());
+    verify(session, atMostOnce()).setAttribute(any(), any());
+    verify(context, atMostOnce()).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS),
+      any(Response.class));
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentity() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+        .thenReturn(RESPONSE_JSON);
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertTrue(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProviderFactory() {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var keycloakSessionFactory = mock(KeycloakSessionFactory.class);
+    when(session.getKeycloakSessionFactory()).thenReturn(keycloakSessionFactory);
+    when(keycloakSessionFactory.getProviderFactory(IdentityProvider.class, PROVIDER_ID))
+      .thenReturn(null);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+    when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+    when(context.getExecution()).thenReturn(executionModel);
+    when(executionModel.getId()).thenReturn(EXECUTION_ID);
+    when(context.form()).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+    when(context.getAuthenticationSession()).thenReturn(authSession);
+
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+    assertFalse(result);
+
+    verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProviderModel() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(null);
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+        .thenReturn(RESPONSE_JSON);
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithLinkOnlyIdentityProviderModel() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    var identityProviderModel = createIdentityProviderModel();
+    identityProviderModel.setLinkOnly(true);
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(identityProviderModel);
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+        .thenReturn(RESPONSE_JSON);
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithDisabledFederatedIdentity() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    var identityProviderModel = createIdentityProviderModel();
+    identityProviderModel.setEnabled(false);
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(identityProviderModel);
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+        .thenReturn(RESPONSE_JSON);
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithNoIdentityProvider() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+    when(identityProviderFactory.create(any(), any())).thenReturn(null);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+        .thenReturn(RESPONSE_JSON);
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithWrongIdentityProvider() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var identityProvider = mock(IdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(identityProvider);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8)))
+        .thenReturn(RESPONSE_JSON);
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithNoAccessToken() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8))).thenReturn("");
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithFederatedIdentityAndWithNoOkStatus() throws IOException {
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var federatedIdentityModel = mock(FederatedIdentityModel.class);
+    when(federatedIdentityModel.getUserName()).thenReturn(USERNAME);
+    when(context.getSession().removeAttribute("federatedIdentityModel")).thenReturn(federatedIdentityModel);
+
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(session.identityProviders().getById(PROVIDER_ID)).thenReturn(createIdentityProviderModel());
+    when(session.users()).thenReturn(userProvider);
+    when(session.getProvider(PasswordHashProvider.class)).thenReturn(passwordHashProvider);
+    when(httpRequest.getDecodedFormParameters()).thenReturn(createFormData(null));
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(userModel);
+
+    var config = mock(OIDCIdentityProviderConfig.class);
+    when(config.getTokenUrl()).thenReturn(URL);
+    when(config.getClientId()).thenReturn(CLIENT_ID);
+    when(config.getClientSecret()).thenReturn(CLIENT_SECRET);
+
+    var oidcIdentityProvider = mock(OIDCIdentityProvider.class);
+    when(identityProviderFactory.create(any(), any())).thenReturn(oidcIdentityProvider);
+    when(oidcIdentityProvider.getConfig()).thenReturn(config);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      var httpResponse = mock(CloseableHttpResponse.class);
+      when(httpResponse.getStatusLine()).thenReturn(mock(StatusLine.class));
+      when(httpResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_GATEWAY_TIMEOUT);
+
+      var httpEntity = mock(HttpEntity.class);
+      when(httpResponse.getEntity()).thenReturn(httpEntity);
+      when(httpEntity.getContentType()).thenReturn(mock(Header.class));
+      when(httpEntity.getContent()).thenReturn(mock(InputStream.class));
+
+      var httpClient = mock(CloseableHttpClient.class);
+      when(httpClient.execute(any())).thenReturn(httpResponse);
+      mockedStatic.when(() -> EntityUtils.toString(eq(httpEntity), eq(StandardCharsets.UTF_8))).thenReturn("");
+      var httpClientProvider = mock(HttpClientProvider.class);
+      when(httpClientProvider.getHttpClient()).thenReturn(httpClient);
+      when(session.getProvider(HttpClientProvider.class)).thenReturn(httpClientProvider);
+      when(federatedIdentityModel.getIdentityProvider()).thenReturn(PROVIDER_ID);
+      when(userProvider.getFederatedIdentitiesStream(any(), any())).thenReturn(Stream.of(federatedIdentityModel));
+      when(context.getExecution()).thenReturn(executionModel);
+      when(executionModel.getId()).thenReturn(EXECUTION_ID);
+      when(context.form()).thenReturn(loginFormsProvider);
+      when(loginFormsProvider.setExecution(anyString())).thenReturn(loginFormsProvider);
+      when(context.getAuthenticationSession()).thenReturn(authSession);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @Test
+  void testValidatePasswordWithNoFederatedIdentity() {
+    when(session.removeAttribute("federatedIdentityModel")).thenReturn(null);
+
+    var userModel = mock(InMemoryUserAdapter.class);
+    when(userModel.getId()).thenReturn(USER_ID);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.getUsername()).thenReturn(USERNAME);
+    when(userModel.credentialManager()).thenReturn(mock(CredentialModel.SECRET));
+    when(userModel.credentialManager().isValid(any(CredentialInput[].class))).thenReturn(true);
+
+    var result = usernamePasswordForm.validatePassword(context, userModel, createFormData(USERNAME), true);
+
+    assertTrue(result);
+
+    verify(userModel.credentialManager(), atMostOnce()).isValid(any(CredentialInput[].class));
+  }
+
+  private MultivaluedHashMap<String, String> createFormData(String username) {
+    var formData = new MultivaluedHashMap<String, String>();
+    formData.add("username", username);
+    formData.add("password", FolioEcsUsernamePasswordFormTest.PASSWORD);
+    return formData;
+  }
+
+  private FederatedIdentityModel createFederatedIdentityModel() {
+    return new FederatedIdentityModel(PROVIDER_ALIAS, USERNAME, null);
+  }
+
+  private IdentityProviderModel createIdentityProviderModel() {
+    var identityProviderModel = new IdentityProviderModel();
+    identityProviderModel.setProviderId(PROVIDER_ID);
+    identityProviderModel.setAlias(PROVIDER_ALIAS);
+    identityProviderModel.setEnabled(true);
+    return identityProviderModel;
+  }
+}

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
@@ -133,7 +133,7 @@ class FolioEcsUsernamePasswordFormTest {
 
   @Test
   void testActionWithCancellation() {
-    // Cancel Form Data Field
+    // With Cancel Form Data Field
     var formData = new MultivaluedHashMap<String, String>();
     formData.add("cancel", "");
 
@@ -160,9 +160,10 @@ class FolioEcsUsernamePasswordFormTest {
   }
 
   @Test
-  void testActionWithoutFederatedIdentity() {
+  void testActionWithNoFederatedIdentity() {
     createIdentityProviders();
     createPasswordHashProvider(USERNAME);
+    // No Federated Identity
     createFederatedIdentities(null, Stream.of());
 
     usernamePasswordForm.action(context);
@@ -175,6 +176,7 @@ class FolioEcsUsernamePasswordFormTest {
   @Test
   void testActionWithFederatedIdentityAndWithNoUsername() {
     createIdentityProviders();
+    // No Username
     createPasswordHashProvider(null);
     var userModel = createInMemoryUserAdapterUserModel();
     createFederatedIdentities(userModel, Stream.of(createFederatedIdentityModelObj()));
@@ -384,6 +386,36 @@ class FolioEcsUsernamePasswordFormTest {
   void testValidatePasswordWithFederatedIdentityAndWithNoOkStatus() throws IOException {
     createIdentityProviderByAlias(createIdentityProviderModelObj());
     var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
+    createOidcIdentityProvider(oidcIdentityProviderConfig);
+    var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
+    bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);
+    var userModel = createInMemoryUserAdapterUserModel();
+    bindFederatedIdentity(userModel);
+    createPasswordHashProvider(null);
+
+    try (var mockedStatic = mockStatic(EntityUtils.class)) {
+      // No OK Status (Error code 504)
+      var httpResponse = createHttpResponse(HttpStatus.SC_GATEWAY_TIMEOUT);
+      var httpEntity = createHttpEntity(httpResponse);
+      var httpClient = createHttpClient(httpResponse, mockedStatic, httpEntity, "");
+      createHttpClientProvider(httpClient);
+
+      var result = usernamePasswordForm.validatePassword(context, userModel, createFormDataObj(USERNAME), true);
+
+      assertFalse(result);
+
+      verify(userModel.credentialManager(), never()).isValid(any(CredentialInput[].class));
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testValidatePasswordWithFederatedIdentityAndWithNoClientSecret(boolean emptyClientSecret) throws IOException {
+    createIdentityProviderByAlias(createIdentityProviderModelObj());
+    var oidcIdentityProviderConfig = mock(OIDCIdentityProviderConfig.class);
+    when(oidcIdentityProviderConfig.getTokenUrl()).thenReturn(URL);
+    when(oidcIdentityProviderConfig.getClientId()).thenReturn(CLIENT_ID);
+    when(oidcIdentityProviderConfig.getClientSecret()).thenReturn(emptyClientSecret ? "" : null);
     createOidcIdentityProvider(oidcIdentityProviderConfig);
     var federatedIdentityModel = createFederatedIdentityModelWithRemoveAttr();
     bindIdentityProviderAndFederatedIdentityModel(federatedIdentityModel);

--- a/pom.xml
+++ b/pom.xml
@@ -263,5 +263,6 @@
 
   <modules>
     <module>detect-folio-user</module>
+    <module>ecs-folio-authenticator</module>
   </modules>
 </project>


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/EUREKA-650>
- <https://folio-org.atlassian.net/browse/FKP-3>

## Approach

- Add new a Keycloak plugin enhancing ECS login functionality for the member tenants
- Replace deprecated methods:
  - Old: 
      - <https://github.com/folio-org/folio-keycloak-plugins/compare/master...feature/ecs-folio-authenticator-v2#diff-abbeb384ef46286b1d94f3d21945b2008c74d71dd18440a37aeffec75eea5880R100>
      - <https://github.com/folio-org/folio-keycloak-plugins/compare/master...feature/ecs-folio-authenticator-v2#diff-abbeb384ef46286b1d94f3d21945b2008c74d71dd18440a37aeffec75eea5880R152>
   - New:
     - <https://github.com/folio-org/folio-keycloak-plugins/pull/6/files#diff-ebda6a018e8ce5d6b4a6afa18c2282b7962fce8df3601d17d0c6eabc1a9f678aR113>
     - <https://github.com/folio-org/folio-keycloak-plugins/pull/6/files#diff-ebda6a018e8ce5d6b4a6afa18c2282b7962fce8df3601d17d0c6eabc1a9f678aR170>
- Remove unused classes
- Remove 1 Service Loader definition
- Update logging to use a dedicated Logger
- Update & add new test dependencies,
- And add test coverage with Unit Tests
- Derived from: <https://github.com/folio-org/folio-keycloak-plugins/compare/master...feature/ecs-folio-authenticator-v2>