### PR TITLE
FKP-6: Circular class dep IdpDetectExistingFolioBrokerUserAuthenticator

### DIFF
--- a/detect-folio-user/src/main/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticator.java
+++ b/detect-folio-user/src/main/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticator.java
@@ -1,9 +1,8 @@
 package org.folio.authentication;
 
-import static org.folio.authentication.IdpDetectExistingFolioBrokerUserAuthenticatorFactory.EXTERNAL_ID_PROPERTY_DEFAULT_VALUE;
-import static org.folio.authentication.IdpDetectExistingFolioBrokerUserAuthenticatorFactory.EXTERNAL_ID_PROPERTY_NAME;
 import static org.keycloak.models.UserModel.EMAIL;
 import static org.keycloak.models.UserModel.USERNAME;
+import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
 
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.authenticators.broker.IdpDetectExistingBrokerUserAuthenticator;
@@ -11,8 +10,11 @@ import org.keycloak.authentication.authenticators.broker.util.ExistingUserInfo;
 import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderConfigProperty;
 
 public class IdpDetectExistingFolioBrokerUserAuthenticator extends IdpDetectExistingBrokerUserAuthenticator {
+  public static final String EXTERNAL_ID_PROPERTY_NAME = "externalIdAttributeName";
+  public static final String EXTERNAL_ID_PROPERTY_DEFAULT_VALUE = "externalId";
 
   @Override
   protected ExistingUserInfo checkExistingUser(AuthenticationFlowContext context, String username,
@@ -40,5 +42,17 @@ public class IdpDetectExistingFolioBrokerUserAuthenticator extends IdpDetectExis
   private ExistingUserInfo toExistingUserInfo(UserModel user, boolean matchedByEmail) {
     return new ExistingUserInfo(user.getId(), matchedByEmail ? EMAIL : USERNAME,
       matchedByEmail ? user.getEmail() : user.getUsername());
+  }
+
+  protected static ProviderConfigProperty getProviderConfigProperty() {
+    var customProperty = new ProviderConfigProperty();
+    customProperty.setName(EXTERNAL_ID_PROPERTY_NAME);
+    customProperty.setLabel("User attribute containing external ID");
+    customProperty.setType(STRING_TYPE);
+    customProperty.setHelpText("The external ID attribute of a user profile should contain an email or a "
+      + "username by which Keycloak user will be matched with the external user");
+    customProperty.setDefaultValue(EXTERNAL_ID_PROPERTY_DEFAULT_VALUE);
+
+    return customProperty;
   }
 }

--- a/detect-folio-user/src/main/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticatorFactory.java
+++ b/detect-folio-user/src/main/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticatorFactory.java
@@ -2,7 +2,6 @@ package org.folio.authentication;
 
 import static org.keycloak.models.AuthenticationExecutionModel.Requirement.DISABLED;
 import static org.keycloak.models.AuthenticationExecutionModel.Requirement.REQUIRED;
-import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
 
 import java.util.List;
 import org.keycloak.Config;
@@ -14,10 +13,8 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 
 public class IdpDetectExistingFolioBrokerUserAuthenticatorFactory implements AuthenticatorFactory {
-
-  public static final String EXTERNAL_ID_PROPERTY_NAME = "externalIdAttributeName";
-  public static final String EXTERNAL_ID_PROPERTY_DEFAULT_VALUE = "externalId";
   public static final String PROVIDER_ID = "idp-detect-folio-broker-user";
+
   private static final IdpDetectExistingFolioBrokerUserAuthenticator SINGLETON =
     new IdpDetectExistingFolioBrokerUserAuthenticator();
 
@@ -73,14 +70,6 @@ public class IdpDetectExistingFolioBrokerUserAuthenticatorFactory implements Aut
 
   @Override
   public List<ProviderConfigProperty> getConfigProperties() {
-    var customProperty = new ProviderConfigProperty();
-    customProperty.setName(EXTERNAL_ID_PROPERTY_NAME);
-    customProperty.setLabel("User attribute containing external ID");
-    customProperty.setType(STRING_TYPE);
-    customProperty.setHelpText("The external ID attribute of a user profile should contain an email or a "
-      + "username by which Keycloak user will be matched with the external user");
-    customProperty.setDefaultValue(EXTERNAL_ID_PROPERTY_DEFAULT_VALUE);
-
-    return List.of(customProperty);
+    return List.of(IdpDetectExistingFolioBrokerUserAuthenticator.getProviderConfigProperty());
   }
 }

--- a/detect-folio-user/src/test/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticatorFactoryTest.java
+++ b/detect-folio-user/src/test/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticatorFactoryTest.java
@@ -1,6 +1,6 @@
 package org.folio.authentication;
 
-import static org.folio.authentication.IdpDetectExistingFolioBrokerUserAuthenticatorFactory.EXTERNAL_ID_PROPERTY_NAME;
+import static org.folio.authentication.IdpDetectExistingFolioBrokerUserAuthenticator.EXTERNAL_ID_PROPERTY_NAME;
 import static org.folio.authentication.IdpDetectExistingFolioBrokerUserAuthenticatorFactory.PROVIDER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/detect-folio-user/src/test/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticatorTest.java
+++ b/detect-folio-user/src/test/java/org/folio/authentication/IdpDetectExistingFolioBrokerUserAuthenticatorTest.java
@@ -81,7 +81,7 @@ class IdpDetectExistingFolioBrokerUserAuthenticatorTest {
     var result = mock(AuthenticationFlowContext.class);
     var config = new HashMap<String, String>();
     if (externalIdAttrName != null) {
-      config.put(IdpDetectExistingFolioBrokerUserAuthenticatorFactory.EXTERNAL_ID_PROPERTY_NAME, externalIdAttrName);
+      config.put(IdpDetectExistingFolioBrokerUserAuthenticator.EXTERNAL_ID_PROPERTY_NAME, externalIdAttrName);
     }
     var authConfig = mock(AuthenticatorConfigModel.class);
     lenient().when(result.getAuthenticatorConfig()).thenReturn(authConfig);


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FKP-6

## Purpose
Snyk found a class cycle:

https://sonarcloud.io/project/issues?open=AZS8mjYFJbn_5jTr-vDl&id=org.folio.keycloak%3Afolio-keycloak-plugins

IdpDetectExistingFolioBrokerUserAuthenticator and
IdpDetectExistingFolioBrokerUserAuthenticatorFactory call each other.

## Approach

This can easily been fixed by moving code and static variables from the factory into a new function getProviderConfigProperty() in the other class.

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.