### PR TITLE
FKP-7: Upgrade keycloak from EOL 26.1.4 to current 26.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.release>21</maven.compiler.release>
     <junit.version>5.12.1</junit.version>
-    <keycloak.version>26.1.4</keycloak.version>
+    <keycloak.version>26.2.4</keycloak.version>
     <mockito.version>5.16.1</mockito.version>
     <resteasy.version>6.2.12.Final</resteasy.version>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FKP-7

## Purpose
Keycloak 26.1 is end-of-life (EOL).

Upgrade to latest 26.2.x version: https://github.com/keycloak/keycloak/releases

* See https://github.com/keycloak/keycloak/security/policy#supported-versions : "Supported Versions: Depending on the severity of a vulnerability the issue may be fixed in the current major.minor release of Keycloak, or for lower severity vulnerabilities or hardening in the following major.minor release."
* See https://github.com/keycloak/keycloak/discussions/19937 : "the latest version is the only actively supported version. Therefore any version that is not the latest version is technically end-of-life."

## Approach
Upgrade keycloak from EOL 26.1.4 to current 26.2.4

## TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.