### PR TITLE
[EUREKA-650-2]. Lowercase the username

### DIFF
--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -95,7 +95,9 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
   }
 
   private UserModel getUserFromForm(AuthenticationFlowContext context, MultivaluedMap<String, String> inputData) {
-    String username = Optional.ofNullable(inputData.getFirst(AuthenticationManager.FORM_USERNAME)).orElse("").trim();
+    String username = Optional.ofNullable(inputData.getFirst(AuthenticationManager.FORM_USERNAME))
+      .orElse("")
+      .trim().toLowerCase();
     if (username.isEmpty()) {
       context.getEvent().error(Errors.USER_NOT_FOUND);
       Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_USERNAME);


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/EUREKA-650>

## Approach

- Lowercase the username coming from the user login form when using the ECS authentication plugin
- This is needed to make the request compatible with Keycloak's entities that stores all usernames lower cased
- Test manually by QA on Thunderjet edev deployed with Single Tenant UX enabled

> Central tenant users that were successfully authenticated by the plugin

<img width="1325" height="309" alt="image" src="https://github.com/user-attachments/assets/d0cc4f24-9abc-4740-afff-591a82853e7c" />
