### PR TITLE
FKP-15. Error during wrong username/password login on ECS

### DIFF
--- a/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
+++ b/ecs-folio-authenticator/src/main/java/org/folio/authentication/FolioEcsUsernamePasswordForm.java
@@ -65,6 +65,11 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
 
     UserModel userModel = getUserFromForm(context, formData);
 
+    if (userModel == null) {
+      log.warnf("action:: User not found from form, skipping federated identity lookup");
+      return;
+    }
+
     Optional<FederatedIdentityModel> identityModelOptional =
       context.getSession().users().getFederatedIdentitiesStream(context.getRealm(), userModel).findFirst();
 
@@ -230,8 +235,12 @@ public class FolioEcsUsernamePasswordForm extends UsernamePasswordForm {
     try {
       String responseString = sendTokenRequest(tokenUrl, clientId, clientSecret, username, password, context);
       return processTokenResponse(context, responseString);
+    } catch (AuthenticationException e) {
+      log.warnf("Authentication failed for user '%s' with external IdP: %s",
+        username, e.getMessage());
+      return false;
     } catch (Exception e) {
-      log.error("Error during authentication with external IdP", e);
+      log.error("Unexpected error during authentication with external IdP", e);
       return false;
     }
   }

--- a/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
+++ b/ecs-folio-authenticator/src/test/java/org/folio/authentication/FolioEcsUsernamePasswordFormTest.java
@@ -5,11 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -174,6 +174,36 @@ class FolioEcsUsernamePasswordFormTest {
   }
 
   @Test
+  void testActionWithEmptyUsername() {
+    createPasswordHashProvider("");
+
+    when(loginFormsProvider.setError(anyString(), any())).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.createLoginUsernamePassword()).thenReturn(mock(Response.class));
+
+    usernamePasswordForm.action(context);
+
+    verify(context).failureChallenge(eq(AuthenticationFlowError.INVALID_USER), any(Response.class));
+    verify(userProvider, never()).getFederatedIdentitiesStream(any(), any());
+  }
+
+  @Test
+  void testActionWithUserNotFound() {
+    // User not found by any lookup should return null and not cause NPE
+    createIdentityProviders();
+    createPasswordHashProvider(USERNAME);
+
+    when(userProvider.getUserByFederatedIdentity(any(), any())).thenReturn(null);
+
+    when(loginFormsProvider.setError(anyString(), any())).thenReturn(loginFormsProvider);
+    when(loginFormsProvider.createLoginUsernamePassword()).thenReturn(mock(Response.class));
+
+    usernamePasswordForm.action(context);
+
+    verify(context, never()).setUser(any(UserModel.class));
+    verify(session, never()).setAttribute(eq(FEDERATED_IDENTITY_MODEL), any(FederatedIdentityModel.class));
+  }
+
+  @Test
   void testActionWithFederatedIdentityAndWithNoUsername() {
     createIdentityProviders();
     // No Username
@@ -192,7 +222,7 @@ class FolioEcsUsernamePasswordFormTest {
   @ParameterizedTest
   @ValueSource(strings = {UserModel.EMAIL, UserModel.USERNAME})
   void testActionWithFederatedIdentityAndWithDuplicatedUsername(String field) {
-    createIdentityProviders();
+    createIdentityProvidersWithQuery();
     createPasswordHashProvider(USERNAME);
 
     // Duplicated Email or Username Field
@@ -206,10 +236,10 @@ class FolioEcsUsernamePasswordFormTest {
 
     usernamePasswordForm.action(context);
 
-    verify(context, atMostOnce()).setUser(any());
-    verify(authSession, times(3)).setAuthNote(any(), any());
-    verify(session, atMostOnce()).setAttribute(any(), any());
-    verify(context, atMostOnce()).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS),
+    verify(context, never()).setUser(any(UserModel.class));
+    verify(authSession, atLeastOnce()).setAuthNote(any(), any());
+    verify(session, never()).setAttribute(eq(FEDERATED_IDENTITY_MODEL), any(FederatedIdentityModel.class));
+    verify(context).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS),
       any(Response.class));
   }
 
@@ -382,8 +412,9 @@ class FolioEcsUsernamePasswordFormTest {
     }
   }
 
-  @Test
-  void testValidatePasswordWithFederatedIdentityAndWithNoOkStatus() throws IOException {
+  @ParameterizedTest
+  @ValueSource(ints = {HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_GATEWAY_TIMEOUT})
+  void testValidatePasswordWithFederatedIdentityAndWithNonOkStatus(int httpStatusCode) throws IOException {
     createIdentityProviderByAlias(createIdentityProviderModelObj());
     var oidcIdentityProviderConfig = createOidcIdentityProviderConfig();
     createOidcIdentityProvider(oidcIdentityProviderConfig);
@@ -394,8 +425,7 @@ class FolioEcsUsernamePasswordFormTest {
     createPasswordHashProvider(null);
 
     try (var mockedStatic = mockStatic(EntityUtils.class)) {
-      // No OK Status (Error code 504)
-      var httpResponse = createHttpResponse(HttpStatus.SC_GATEWAY_TIMEOUT);
+      var httpResponse = createHttpResponse(httpStatusCode);
       var httpEntity = createHttpEntity(httpResponse);
       var httpClient = createHttpClient(httpResponse, mockedStatic, httpEntity, "");
       createHttpClientProvider(httpClient);
@@ -472,6 +502,11 @@ class FolioEcsUsernamePasswordFormTest {
   private void createIdentityProviders() {
     when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
     when(session.identityProviders().getAllStream()).thenReturn(Stream.of(createIdentityProviderModelObj()));
+  }
+
+  private void createIdentityProvidersWithQuery() {
+    when(session.identityProviders()).thenReturn(identityProviderStorageProvider);
+    when(identityProviderStorageProvider.getAllStream(any())).thenReturn(Stream.of(createIdentityProviderModelObj()));
   }
 
   private void createIdentityProviderByAlias(IdentityProviderModel identityProviderModelObj) {


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/FKP-15

 Summary                                                                                                                                                                                                                          

  - Fix NullPointerException in FolioEcsUsernamePasswordForm.action() when user is not found by adding a null check after getUserFromForm(). When the user is null, the method returns early since getUserFromForm() already sets
  the appropriate failure challenge with the "Invalid username or password" message via the parent class
  - Distinguish expected authentication failures (HTTP 401) from unexpected errors in federated IdP authentication by splitting the catch block — 401 is now logged at WARN level without stack trace, while actual errors remain
  at ERROR

Verified locally with eureka-cli, works good. 
Before the change when login with incorrect username:
<img width="1024" height="713" alt="image" src="https://github.com/user-attachments/assets/76d6ebe3-46c5-4221-9463-1f52867ece12" />

After the change:
<img width="596" height="552" alt="image" src="https://github.com/user-attachments/assets/4140ff5a-3db8-4d51-bbd0-47c7186467ce" />
