### PR TITLE
FKP-26: Update keycloak version to 26.6.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-## 26.5.5 (in progress)
+## 26.6.0 (in progress)
+* Update keycloak version to 26.6.2 (FKP-26)
 
 ## 26.5.4 (03.04.2026)
 * Update keycloak version to 26.5.7 (FKP-24)

--- a/detect-folio-user/pom.xml
+++ b/detect-folio-user/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-keycloak-plugins</artifactId>
-    <version>26.5.5-SNAPSHOT</version>
+    <version>26.6.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.folio.authentication</groupId>

--- a/ecs-folio-authenticator/pom.xml
+++ b/ecs-folio-authenticator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-keycloak-plugins</artifactId>
-    <version>26.5.5-SNAPSHOT</version>
+    <version>26.6.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.folio.authentication</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-keycloak-plugins</artifactId>
-  <version>26.5.5-SNAPSHOT</version>
+  <version>26.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -13,7 +13,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.release>21</maven.compiler.release>
     <junit.version>5.14.0</junit.version>
-    <keycloak.version>26.5.7</keycloak.version>
+    <keycloak.version>26.6.2</keycloak.version>
     <mockito.version>5.20.0</mockito.version>
     <resteasy.version>6.2.14.Final</resteasy.version>
 


### PR DESCRIPTION
- Update keycloak version to 26.6.2
- Increment the minor version of `folio-keycloak-plugins` to `26.6.0-SNAPSHOT` (from `26.5.5-SNAPSHOT`) to match with keycloak's minor version. Is that ok?